### PR TITLE
Set sensitive config fields to Secret

### DIFF
--- a/provider/cmd/pulumi-resource-okta/schema.json
+++ b/provider/cmd/pulumi-resource-okta/schema.json
@@ -71,11 +71,13 @@
         "variables": {
             "accessToken": {
                 "type": "string",
-                "description": "Bearer token granting privileges to Okta API.\n"
+                "description": "Bearer token granting privileges to Okta API.\n",
+                "secret": true
             },
             "apiToken": {
                 "type": "string",
-                "description": "API Token granting privileges to Okta API.\n"
+                "description": "API Token granting privileges to Okta API.\n",
+                "secret": true
             },
             "backoff": {
                 "type": "boolean",
@@ -123,7 +125,8 @@
             },
             "privateKey": {
                 "type": "string",
-                "description": "API Token granting privileges to Okta API.\n"
+                "description": "API Token granting privileges to Okta API.\n",
+                "secret": true
             },
             "privateKeyId": {
                 "type": "string",
@@ -1972,11 +1975,13 @@
         "properties": {
             "accessToken": {
                 "type": "string",
-                "description": "Bearer token granting privileges to Okta API.\n"
+                "description": "Bearer token granting privileges to Okta API.\n",
+                "secret": true
             },
             "apiToken": {
                 "type": "string",
-                "description": "API Token granting privileges to Okta API.\n"
+                "description": "API Token granting privileges to Okta API.\n",
+                "secret": true
             },
             "backoff": {
                 "type": "boolean",
@@ -2024,7 +2029,8 @@
             },
             "privateKey": {
                 "type": "string",
-                "description": "API Token granting privileges to Okta API.\n"
+                "description": "API Token granting privileges to Okta API.\n",
+                "secret": true
             },
             "privateKeyId": {
                 "type": "string",
@@ -2045,11 +2051,13 @@
         "inputProperties": {
             "accessToken": {
                 "type": "string",
-                "description": "Bearer token granting privileges to Okta API.\n"
+                "description": "Bearer token granting privileges to Okta API.\n",
+                "secret": true
             },
             "apiToken": {
                 "type": "string",
-                "description": "API Token granting privileges to Okta API.\n"
+                "description": "API Token granting privileges to Okta API.\n",
+                "secret": true
             },
             "backoff": {
                 "type": "boolean",
@@ -2097,7 +2105,8 @@
             },
             "privateKey": {
                 "type": "string",
-                "description": "API Token granting privileges to Okta API.\n"
+                "description": "API Token granting privileges to Okta API.\n",
+                "secret": true
             },
             "privateKeyId": {
                 "type": "string",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -91,15 +91,25 @@ func Provider() tfbridge.ProviderInfo {
 		okta.NewFrameworkProvider(okta.OktaTerraformProviderVersion),
 	)
 	prov := tfbridge.ProviderInfo{
-		P:                 p,
-		Name:              "okta",
-		Description:       "A Pulumi package for creating and managing okta resources.",
-		Keywords:          []string{"pulumi", "okta"},
-		License:           "Apache-2.0",
-		Homepage:          "https://pulumi.io",
-		GitHubOrg:         "okta",
-		Repository:        "https://github.com/pulumi/pulumi-okta",
-		Config:            map[string]*tfbridge.SchemaInfo{},
+		P:           p,
+		Name:        "okta",
+		Description: "A Pulumi package for creating and managing okta resources.",
+		Keywords:    []string{"pulumi", "okta"},
+		License:     "Apache-2.0",
+		Homepage:    "https://pulumi.io",
+		GitHubOrg:   "okta",
+		Repository:  "https://github.com/pulumi/pulumi-okta",
+		Config: map[string]*tfbridge.SchemaInfo{
+			"api_token": {
+				Secret: tfbridge.True(),
+			},
+			"access_token": {
+				Secret: tfbridge.True(),
+			},
+			"private_key": {
+				Secret: tfbridge.True(),
+			},
+		},
 		UpstreamRepoPath:  "./upstream",
 		Version:           version.Version,
 		TFProviderVersion: okta.OktaTerraformProviderVersion,

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -84,6 +84,12 @@ namespace Pulumi.Okta
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                AdditionalSecretOutputs =
+                {
+                    "accessToken",
+                    "apiToken",
+                    "privateKey",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
@@ -94,17 +100,37 @@ namespace Pulumi.Okta
 
     public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
+        [Input("accessToken")]
+        private Input<string>? _accessToken;
+
         /// <summary>
         /// Bearer token granting privileges to Okta API.
         /// </summary>
-        [Input("accessToken")]
-        public Input<string>? AccessToken { get; set; }
+        public Input<string>? AccessToken
+        {
+            get => _accessToken;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _accessToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
+
+        [Input("apiToken")]
+        private Input<string>? _apiToken;
 
         /// <summary>
         /// API Token granting privileges to Okta API.
         /// </summary>
-        [Input("apiToken")]
-        public Input<string>? ApiToken { get; set; }
+        public Input<string>? ApiToken
+        {
+            get => _apiToken;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _apiToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
 
         /// <summary>
         /// Use exponential back off strategy for rate limits.
@@ -175,11 +201,21 @@ namespace Pulumi.Okta
         [Input("parallelism", json: true)]
         public Input<int>? Parallelism { get; set; }
 
+        [Input("privateKey")]
+        private Input<string>? _privateKey;
+
         /// <summary>
         /// API Token granting privileges to Okta API.
         /// </summary>
-        [Input("privateKey")]
-        public Input<string>? PrivateKey { get; set; }
+        public Input<string>? PrivateKey
+        {
+            get => _privateKey;
+            set
+            {
+                var emptySecret = Output.CreateSecret(0);
+                _privateKey = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
+            }
+        }
 
         /// <summary>
         /// API Token Id granting privileges to Okta API.

--- a/sdk/go/okta/provider.go
+++ b/sdk/go/okta/provider.go
@@ -43,6 +43,21 @@ func NewProvider(ctx *pulumi.Context,
 		args = &ProviderArgs{}
 	}
 
+	if args.AccessToken != nil {
+		args.AccessToken = pulumi.ToSecret(args.AccessToken).(pulumi.StringPtrInput)
+	}
+	if args.ApiToken != nil {
+		args.ApiToken = pulumi.ToSecret(args.ApiToken).(pulumi.StringPtrInput)
+	}
+	if args.PrivateKey != nil {
+		args.PrivateKey = pulumi.ToSecret(args.PrivateKey).(pulumi.StringPtrInput)
+	}
+	secrets := pulumi.AdditionalSecretOutputs([]string{
+		"accessToken",
+		"apiToken",
+		"privateKey",
+	})
+	opts = append(opts, secrets)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:okta", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/okta/Provider.java
+++ b/sdk/java/src/main/java/com/pulumi/okta/Provider.java
@@ -10,6 +10,7 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.okta.ProviderArgs;
 import com.pulumi.okta.Utilities;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -163,6 +164,11 @@ public class Provider extends com.pulumi.resources.ProviderResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .additionalSecretOutputs(List.of(
+                "accessToken",
+                "apiToken",
+                "privateKey"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -69,8 +69,8 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            resourceInputs["accessToken"] = args ? args.accessToken : undefined;
-            resourceInputs["apiToken"] = args ? args.apiToken : undefined;
+            resourceInputs["accessToken"] = args?.accessToken ? pulumi.secret(args.accessToken) : undefined;
+            resourceInputs["apiToken"] = args?.apiToken ? pulumi.secret(args.apiToken) : undefined;
             resourceInputs["backoff"] = pulumi.output(args ? args.backoff : undefined).apply(JSON.stringify);
             resourceInputs["baseUrl"] = args ? args.baseUrl : undefined;
             resourceInputs["clientId"] = args ? args.clientId : undefined;
@@ -82,12 +82,14 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["minWaitSeconds"] = pulumi.output(args ? args.minWaitSeconds : undefined).apply(JSON.stringify);
             resourceInputs["orgName"] = args ? args.orgName : undefined;
             resourceInputs["parallelism"] = pulumi.output(args ? args.parallelism : undefined).apply(JSON.stringify);
-            resourceInputs["privateKey"] = args ? args.privateKey : undefined;
+            resourceInputs["privateKey"] = args?.privateKey ? pulumi.secret(args.privateKey) : undefined;
             resourceInputs["privateKeyId"] = args ? args.privateKeyId : undefined;
             resourceInputs["requestTimeout"] = pulumi.output(args ? args.requestTimeout : undefined).apply(JSON.stringify);
             resourceInputs["scopes"] = pulumi.output(args ? args.scopes : undefined).apply(JSON.stringify);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const secretOpts = { additionalSecretOutputs: ["accessToken", "apiToken", "privateKey"] };
+        opts = pulumi.mergeOptions(opts, secretOpts);
         super(Provider.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_okta/provider.py
+++ b/sdk/python/pulumi_okta/provider.py
@@ -405,8 +405,8 @@ class Provider(pulumi.ProviderResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
-            __props__.__dict__["access_token"] = access_token
-            __props__.__dict__["api_token"] = api_token
+            __props__.__dict__["access_token"] = None if access_token is None else pulumi.Output.secret(access_token)
+            __props__.__dict__["api_token"] = None if api_token is None else pulumi.Output.secret(api_token)
             __props__.__dict__["backoff"] = pulumi.Output.from_input(backoff).apply(pulumi.runtime.to_json) if backoff is not None else None
             __props__.__dict__["base_url"] = base_url
             __props__.__dict__["client_id"] = client_id
@@ -418,10 +418,12 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["min_wait_seconds"] = pulumi.Output.from_input(min_wait_seconds).apply(pulumi.runtime.to_json) if min_wait_seconds is not None else None
             __props__.__dict__["org_name"] = org_name
             __props__.__dict__["parallelism"] = pulumi.Output.from_input(parallelism).apply(pulumi.runtime.to_json) if parallelism is not None else None
-            __props__.__dict__["private_key"] = private_key
+            __props__.__dict__["private_key"] = None if private_key is None else pulumi.Output.secret(private_key)
             __props__.__dict__["private_key_id"] = private_key_id
             __props__.__dict__["request_timeout"] = pulumi.Output.from_input(request_timeout).apply(pulumi.runtime.to_json) if request_timeout is not None else None
             __props__.__dict__["scopes"] = pulumi.Output.from_input(scopes).apply(pulumi.runtime.to_json) if scopes is not None else None
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["accessToken", "apiToken", "privateKey"])
+        opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(Provider, __self__).__init__(
             'okta',
             resource_name,


### PR DESCRIPTION
These [values are not marked as sensitive upstream](https://github.com/okta/terraform-provider-okta/blob/master/okta/config.go), so we did not pick them up as Secret. Now we mark them as such explicitly.

Fixes #652.