### PR TITLE
Remove `actions.preTest` in favor of `integrationTestProvider`

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -9,15 +9,9 @@ plugins:
   - name: terraform
     version: "1.0.16"
     kind: converter
-
   - name: random
     version: "4.1.1"
 team: ecosystem
-
-actions:
-  preTest:
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
 registryDocs: true
+integrationTestProvider: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
     - name: Run provider tests
-      run: |
-        cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+      if: matrix.testTarget == 'local'
+      working-directory: provider
+      run: go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .


### PR DESCRIPTION
By using ci-mgmt's intended solution for running integration tests in the `provider/` directory, we get a maintained test script and avoid overloading the `actions.preTest` hook to run tests.

Related to https://github.com/pulumi/ci-mgmt/pull/1276, https://github.com/pulumi/ci-mgmt/pull/1274#issuecomment-2582085346